### PR TITLE
Fix ambiguous Username column

### DIFF
--- a/BankDataAccessLayer/LoginRegistersData.cs
+++ b/BankDataAccessLayer/LoginRegistersData.cs
@@ -13,7 +13,7 @@ namespace BankDataAccessLayer
 
             MySqlConnection connection = new MySqlConnection(clsDataAccessSettings.ConnectionString);
 
-            string query = @"Select LoginDateTime, Username, Password, Permission
+            string query = @"Select LoginRegisters.LoginDateTime, Users.Username, Users.Password, Users.Permission
                             from LoginRegisters
                             Join Users on LoginRegisters.UserID = Users.UserID";
 


### PR DESCRIPTION
## Summary
- fix LoginRegisters SQL query to specify Users.Username

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68551a4d4b7c83338c5600be0c14f19d